### PR TITLE
Update CalculateAveragePrecision method for speed

### DIFF
--- a/lib/Evaluator.py
+++ b/lib/Evaluator.py
@@ -231,12 +231,14 @@ class Evaluator:
         mpre.append(0)
         [mpre.append(e) for e in prec]
         mpre.append(0)
-        for i in range(len(mpre)-1, 0, -1):
-            mpre[i-1]=max(mpre[i-1],mpre[i])
         ii = []
-        for i in range(len(mrec)-1):
-            if mrec[1:][i]!=mrec[0:-1][i]:
-                ii.append(i+1)
+        for i,j in zip(range(len(mpre)-1, 0, -1),range(len(mrec)-1)):
+            mpre[i-1]=max(mpre[i-1],mpre[i])
+            if mrec[j]!=mrec[j+1]:
+                ii.append(j+1)
+
+   
+            
         ap = 0
         for i in ii:
             ap = ap + np.sum((mrec[i]-mrec[i-1])*mpre[i])


### PR DESCRIPTION
The previous version of the method CalculateAveragePrecision calculated unnecessary indexing over each iteration in the mrec list. I believe this can be easily simplified by performing a simple comparison which is reflected in this PR.
This simple modification halves the time taken to calculate the same result.