### PR TITLE
Correction for BoundingBox.getRelativeBoundingBox()

### DIFF
--- a/lib/BoundingBox.py
+++ b/lib/BoundingBox.py
@@ -97,7 +97,7 @@ class BoundingBox:
         if imgSize is None and self._width_img is None and self._height_img is None:
             raise IOError(
                 'Parameter \'imgSize\' is required. It is necessary to inform the image size.')
-        if imgSize is None:
+        if imgSize is not None:
             return convertToRelativeValues((imgSize[0], imgSize[1]),
                                            (self._x, self._x2, self._y, self._y2))
         else:

--- a/lib/BoundingBox.py
+++ b/lib/BoundingBox.py
@@ -99,10 +99,10 @@ class BoundingBox:
                 'Parameter \'imgSize\' is required. It is necessary to inform the image size.')
         if imgSize is None:
             return convertToRelativeValues((imgSize[0], imgSize[1]),
-                                           (self._x, self._y, self._w, self._h))
+                                           (self._x, self._x2, self._y, self._y2))
         else:
             return convertToRelativeValues((self._width_img, self._height_img),
-                                           (self._x, self._y, self._w, self._h))
+                                           (self._x, self._x2, self._y, self._y2))
 
     def getImageName(self):
         return self._imageName


### PR DESCRIPTION
`convertToRelativeValues` takes as argument a box with format `(X1, X2, Y1, Y2)`, not `(X1, Y1, W, H)`.

This change has no impact on the mAP computation as `BoundingBox.getRelativeBoundingBox()` is never used throughout the code.