### PR TITLE
Recall is 1 if total positives is 0, not 'nan'

### DIFF
--- a/lib/Evaluator.py
+++ b/lib/Evaluator.py
@@ -123,7 +123,10 @@ class Evaluator:
             # compute precision, recall and average precision
             acc_FP = np.cumsum(FP)
             acc_TP = np.cumsum(TP)
-            rec = acc_TP / npos
+            if npos != 0:
+                rec = acc_TP / npos
+            else:
+                rec = np.ones(len(dects))
             prec = np.divide(acc_TP, (acc_FP + acc_TP))
             # Depending on the method, call the right implementation
             if method == MethodAveragePrecision.EveryPointInterpolation:


### PR DESCRIPTION
If the class does not exist in the testing dataset then the recall is 1, not 'nan', since no positives exist to be missed. Fixes issue #107 