### PR TITLE
change lib/*.py to use relative imports

### DIFF
--- a/_init_paths.py
+++ b/_init_paths.py
@@ -20,5 +20,5 @@ def add_path(path):
 currentPath = os.path.dirname(os.path.realpath(__file__))
 
 # Add lib to PYTHONPATH
-libPath = os.path.join(currentPath, 'lib')
+libPath = os.path.join(currentPath)
 add_path(libPath)

--- a/lib/BoundingBox.py
+++ b/lib/BoundingBox.py
@@ -1,4 +1,4 @@
-from utils import *
+from .utils import *
 
 
 class BoundingBox:

--- a/lib/BoundingBoxes.py
+++ b/lib/BoundingBoxes.py
@@ -1,5 +1,5 @@
-from BoundingBox import *
-from utils import *
+from .BoundingBox import *
+from .utils import *
 
 
 class BoundingBoxes:

--- a/lib/Evaluator.py
+++ b/lib/Evaluator.py
@@ -15,9 +15,9 @@ from collections import Counter
 import matplotlib.pyplot as plt
 import numpy as np
 
-from BoundingBox import *
-from BoundingBoxes import *
-from utils import *
+from .BoundingBox import *
+from .BoundingBoxes import *
+from .utils import *
 
 
 class Evaluator:

--- a/pascalvoc.py
+++ b/pascalvoc.py
@@ -18,10 +18,10 @@ import shutil
 import sys
 
 import _init_paths
-from BoundingBox import BoundingBox
-from BoundingBoxes import BoundingBoxes
-from Evaluator import *
-from utils import BBFormat
+from lib.BoundingBox import BoundingBox
+from lib.BoundingBoxes import BoundingBoxes
+from lib.Evaluator import *
+from lib.utils import BBFormat
 
 
 # Validate formats

--- a/samples/sample_1/_init_paths.py
+++ b/samples/sample_1/_init_paths.py
@@ -20,5 +20,5 @@ def add_path(path):
 currentPath = os.path.dirname(os.path.realpath(__file__))
 
 # Add lib to PYTHONPATH
-libPath = os.path.join(currentPath, '..', '..', 'lib')
+libPath = os.path.join(currentPath, '..', '..')
 add_path(libPath)

--- a/samples/sample_1/sample_1.py
+++ b/samples/sample_1/sample_1.py
@@ -16,9 +16,9 @@ import os
 
 import _init_paths
 import cv2
-from BoundingBox import BoundingBox
-from BoundingBoxes import BoundingBoxes
-from utils import *
+from lib.BoundingBox import BoundingBox
+from lib.BoundingBoxes import BoundingBoxes
+from lib.utils import *
 
 ###########################
 # Defining bounding boxes #

--- a/samples/sample_2/_init_paths.py
+++ b/samples/sample_2/_init_paths.py
@@ -20,5 +20,5 @@ def add_path(path):
 currentPath = os.path.dirname(os.path.realpath(__file__))
 
 # Add lib to PYTHONPATH
-libPath = os.path.join(currentPath, '..', '..', 'lib')
+libPath = os.path.join(currentPath, '..', '..')
 add_path(libPath)

--- a/samples/sample_2/sample_2.py
+++ b/samples/sample_2/sample_2.py
@@ -11,10 +11,10 @@
 ###########################################################################################
 
 import _init_paths
-from BoundingBox import BoundingBox
-from BoundingBoxes import BoundingBoxes
-from Evaluator import *
-from utils import *
+from lib.BoundingBox import BoundingBox
+from lib.BoundingBoxes import BoundingBoxes
+from lib.Evaluator import *
+from lib.utils import *
 
 
 def getBoundingBoxes():


### PR DESCRIPTION
As currently implemented, it's difficult to include your code as a library due to the absolute imports.  This is a fairly minimal adjustment that makes it possible to copy your lib/ directory into a project as a library.

Long term, wrapping the code in pip (#58) is the better option, but short term this makes it possible to just copy your lib/ directory to something like lib/metrics within their projects.  I also think this doesn't make it more difficult to package as a pip module in the future.