### PR TITLE
new metric total_recall added

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,21 @@
+import pickle
+import numpy as np
+import time
+from sklearn import svm
+from skimage.feature import hog
+from skimage import io , transform
+with open('model.pkl', 'rb') as file:
+    model = pickle.load(file)
+image_path = 'Data/truck/000000515266_truck_270.76_99.18_358.77_164.23.jpg'
+image = io.imread(image_path, as_gray=True)
+print(image)
+image = transform.resize(image , (128, 128))
+hog_features = hog(image, orientations=9, pixels_per_cell=(8, 8), cells_per_block=(2, 2))
+start = time.time()
+x = np.array([hog_features])  # Wrap hog_features in a list to create a 2D array
+end = time.time()
+print(end - start)
+predictions = model.predict(x)
+
+
+print(predictions)

--- a/pascalvoc.py
+++ b/pascalvoc.py
@@ -398,6 +398,8 @@ for metricsPerClass in detections:
     totalPositives = metricsPerClass['total positives']
     total_TP = metricsPerClass['total TP']
     total_FP = metricsPerClass['total FP']
+    #total_recall = (total number of True Positive detections) / (total number of ground truth positives) 
+    total_recall = total_TP / totalPositives 
 
     if totalPositives > 0:
         validClasses = validClasses + 1
@@ -409,6 +411,8 @@ for metricsPerClass in detections:
         print('AP: %s (%s)' % (ap_str, cl))
         f.write('\n\nClass: %s' % cl)
         f.write('\nAP: %s' % ap_str)
+        #total_recall = (total number of True Positive detections) / (total number of ground truth positives)
+        f.write('\nOverall recall(sensetivity): %.2f' % total_recall)
         f.write('\nPrecision: %s' % prec)
         f.write('\nRecall: %s' % rec)
 


### PR DESCRIPTION
total_recall = (total number of True Positive detections) / (total number of ground truth positives) , has been added as a metric.
total_recall can be useful for calculating how sensitive a object detection algorithm is to a particular class  